### PR TITLE
Increase teams-webhook-url TextBoxField max length to 500 from 200

### DIFF
--- a/config.php
+++ b/config.php
@@ -40,7 +40,7 @@ class TeamsPluginConfig extends PluginConfig {
                 'label'         => $__('Webhook URL'),
                 'configuration' => array(
                     'size'   => 100,
-                    'length' => 200
+                    'length' => 500
                 ),
                     )),
             'teams-regex-subject-ignore' => new TextboxField([


### PR DESCRIPTION
My Teams Connector start displaying a message to update the URL and the new URL was something like 208 characters,  so the connector no longer worked.