### PR TITLE
Display Message Body in Notification

### DIFF
--- a/config.php
+++ b/config.php
@@ -35,14 +35,14 @@ class TeamsPluginConfig extends PluginConfig {
             'teams'                      => new SectionBreakField(array(
                 'label' => $__('Slack notifier'),
                 'hint'  => $__('Readme first: https://github.com/ipavlovi/osTicket-Microsoft-Teams-plugin')
-                    )),
+            )),
             'teams-webhook-url'          => new TextboxField(array(
                 'label'         => $__('Webhook URL'),
                 'configuration' => array(
                     'size'   => 100,
                     'length' => 500
                 ),
-                    )),
+            )),
             'teams-regex-subject-ignore' => new TextboxField([
                 'label'         => $__('Ignore when subject equals regex'),
                 'hint'          => $__('Auto delimited, always case-insensitive'),
@@ -50,16 +50,12 @@ class TeamsPluginConfig extends PluginConfig {
                     'size'   => 30,
                     'length' => 200
                 ],
-                    ]),
-            'message-template'           => new TextareaField([
-                'label'         => $__('Message Template'),
-                'hint'          => $__('The main text part of the Teams message, uses Ticket Variables, for what the user typed, use variable: %{slack_safe_message}'),
-                // "<%{url}/scp/tickets.php?id=%{ticket.id}|%{ticket.subject}>\n" // Already included as Title
-                'default'       => "%{ticket.name.full} (%{ticket.email}) in *%{ticket.dept}* _%{ticket.topic}_\n\n```%{slack_safe_message}```",
-                'configuration' => [
-                    'html' => FALSE,
-                ]
-                    ])
+            ]),
+            'teams-message-display' => new BooleanField([
+                'label' => $__('Display ticket message body in notification.'),
+                'hint' => $__('Uncheck to hide messages.'),
+                'default' => TRUE
+            ])
         );
     }
 

--- a/teams.php
+++ b/teams.php
@@ -247,6 +247,9 @@ class TeamsPlugin extends Plugin {
                 ]
             ]
         ];
+        if($this->getConfig()->get('teams-message-display')) {
+            array_push($message['sections'], ['text' => $ticket->getMessages()[0]->getBody()->getClean()]);
+        }
 
         return json_encode($message, JSON_UNESCAPED_SLASHES);
 


### PR DESCRIPTION
Replace remenant slack message template in config,  with a checkbox to display the message body. Default to true.