### PR TITLE
Update teams.php

### DIFF
--- a/teams.php
+++ b/teams.php
@@ -241,7 +241,7 @@ class TeamsPlugin extends Plugin {
                     'targets' => [
                         [
                             'os' => 'default',
-                            'uri' => $cfg->getUrl() . '/scp/tickets.php?id=' . $ticket->getId(),
+                            'uri' => $cfg->getUrl() . 'scp/tickets.php?id=' . $ticket->getId(),
                         ]
                     ]
                 ]


### PR DESCRIPTION
Remove unneeded / from line 244. OSticket's getUrl() function includes the terminating /. Code was adding /scp to the end, so you ended up with osticket//scp in the generated URL. This broke some reverse proxy rules we have in our environment. Very similar to issue #3