### PR TITLE
Feature/show latest post not first post

### DIFF
--- a/GitHub - ipavlovi-osTicket-Microsoft-Teams-plugin- osTicket webhook integration to send notifications to MS Teams when new ti.url
+++ b/GitHub - ipavlovi-osTicket-Microsoft-Teams-plugin- osTicket webhook integration to send notifications to MS Teams when new ti.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://github.com/ipavlovi/osTicket-Microsoft-Teams-plugin

--- a/teams.php
+++ b/teams.php
@@ -114,6 +114,9 @@ class TeamsPlugin extends Plugin {
             // Setup curl
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+			// The following addition is necessary if SSL certs are invalid on this box (DEV box)
+			// 'SSL certificate problem: unable to get local issuer certificate'
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, "false");
             curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array(
@@ -226,7 +229,7 @@ class TeamsPlugin extends Plugin {
             '@context' => 'https://schema.org/extensions',
             'summary' => 'Ticket: ' . $ticket->getNumber(),
             'themeColor' => $color,
-            'title' => $this->format_text($type . $ticket->getSubject()),
+            'title' => 'DEV:' . $this->format_text($type . $ticket->getSubject()),
             'sections' => [
                 [
                     'activityTitle' => ($ticket->getName() ? $ticket->getName() : 'Guest ') . ' (sent by ' . $ticket->getEmail() . ')',
@@ -237,7 +240,7 @@ class TeamsPlugin extends Plugin {
             'potentialAction' => [
                 [
                     '@type' => 'OpenUri',
-                    'name' => 'View in osTicket',
+                    'name' => 'View in DEV osTicket',
                     'targets' => [
                         [
                             'os' => 'default',
@@ -248,11 +251,18 @@ class TeamsPlugin extends Plugin {
             ]
         ];
         if($this->getConfig()->get('teams-message-display')) {
-            array_push($message['sections'], ['text' => $ticket->getMessages()[0]->getBody()->getClean()]);
+			$msgArray = $ticket->getMessages();
+			$FirstMessage = $msgArray[0];
+			$LastMessage = $msgArray[count($msgArray)-1];
+			$msgText = $LastMessage;
+			// get the LAST/most recent message that went in, don't just repeat the first one.
+			if($msgText == null)
+			{
+				$msgText = $FirstMessage;
+			}
+			array_push($message['sections'], ['text' => $msgText->getBody()->getClean()]);
         }
 
         return json_encode($message, JSON_UNESCAPED_SLASHES);
-
-    }
-
-}
+    } // end func
+}// end class

--- a/teams.php
+++ b/teams.php
@@ -229,7 +229,7 @@ class TeamsPlugin extends Plugin {
             '@context' => 'https://schema.org/extensions',
             'summary' => 'Ticket: ' . $ticket->getNumber(),
             'themeColor' => $color,
-            'title' => 'DEV:' . $this->format_text($type . $ticket->getSubject()),
+            'title' => 'PROD:' . $this->format_text($type . $ticket->getSubject()),
             'sections' => [
                 [
                     'activityTitle' => ($ticket->getName() ? $ticket->getName() : 'Guest ') . ' (sent by ' . $ticket->getEmail() . ')',
@@ -240,7 +240,7 @@ class TeamsPlugin extends Plugin {
             'potentialAction' => [
                 [
                     '@type' => 'OpenUri',
-                    'name' => 'View in DEV osTicket',
+                    'name' => 'View in PROD osTicket',
                     'targets' => [
                         [
                             'os' => 'default',


### PR DESCRIPTION
Hi - 
Great plugin, this saved me lots of time, thank you!
I've added a few lines to have Teams display the last message, rather than repeating the first message over and over.
I'm not sure if your OsTicket is set up differently or something, but for us it's more useful to see the latest messages.
If it's useful to you, feel free to pull it into your source c

Thanks