### PR TITLE
Ignore Department IDs from Teams Bot

### DIFF
--- a/config.php
+++ b/config.php
@@ -51,6 +51,14 @@ class TeamsPluginConfig extends PluginConfig {
                     'length' => 200
                 ],
             ]),
+			'teams-csv-departmentid' => new TextboxField([
+				'label'         => $__('Ignore department ids'),
+				'hint'          => $__('Comma delimited, ints'),
+				'configuration' => [
+					'size'   => 30,
+					'length' => 200
+				],
+			]),
             'teams-message-display' => new BooleanField([
                 'label' => $__('Display ticket message body in notification.'),
                 'hint' => $__('Uncheck to hide messages.'),

--- a/teams.php
+++ b/teams.php
@@ -107,7 +107,18 @@ class TeamsPlugin extends Plugin {
             error_log("$ticket_subject didn't trigger $regex_subject_ignore");
         }
 
-        // Build the payload with the formatted data:
+		// Check the department id,  see if we want to filter it
+		$teams_csv_departmentid = explode(',',$this->getConfig()->get('teams-csv-departmentid'));
+		if(in_array($ticket->getDeptId(),$teams_csv_departmentid)){
+			$ost->logDebug('Ignored Message', 'Teams notification was not sent because the departmentID (' . $ticket->getDeptId() . ') matched (' . json_encode($teams_csv_departmentid) . ').');
+			return;
+		}
+		else{
+			error_log('DepartmentID: '.$ticket->getDeptId() ." didn't trigger ".json_encode($teams_csv_departmentid));
+		}
+
+
+		// Build the payload with the formatted data:
         $payload = $this->createJsonMessage($ticket, $type);
 
         try {


### PR DESCRIPTION
Our Marketing Department recently wanted to be added to the IT departments Ticket System.  The IT Department uses this bot to get notifications of new tickets and didn't want to get the Marketing Departments tickets in our chat.

Now we can ignore based on the department ID just like the regex subject/body options.